### PR TITLE
Breaking Change: Remove "shared" Attribute

### DIFF
--- a/examples/basic-usage/source/app.d
+++ b/examples/basic-usage/source/app.d
@@ -17,7 +17,7 @@ void main() {
 	
 	// Because we are using the default provider, its LoggerFactory supports setting the log level.
 	import slf4d.default_provider : DefaultLoggerFactory;
-	shared DefaultLoggerFactory factory = cast(shared DefaultLoggerFactory) getLoggerFactory();
+	DefaultLoggerFactory factory = cast(DefaultLoggerFactory) getLoggerFactory();
 	factory.setRootLevel(Levels.TRACE);
 
 	trace("This trace message should show up.");

--- a/examples/custom-provider/source/custom_provider.d
+++ b/examples/custom-provider/source/custom_provider.d
@@ -5,15 +5,15 @@ import slf4d.provider;
 import slf4d.default_provider : DefaultLoggerFactory;
 
 class CustomProvider : LoggingProvider {
-    shared shared(LoggerFactory) getLoggerFactory() {
-        return new shared DefaultLoggerFactory(
-            new shared CustomLogHandler()
+    LoggerFactory getLoggerFactory() {
+        return new DefaultLoggerFactory(
+            new CustomLogHandler()
         );
     }
 }
 
 class CustomLogHandler : LogHandler {
-    shared void handle(immutable LogMessage msg) {
+    void handle(immutable LogMessage msg) {
         import std.stdio;
         writeln(msg.level.name ~ ": " ~ msg.message);
     }
@@ -21,12 +21,10 @@ class CustomLogHandler : LogHandler {
 
 unittest {
     import slf4d.test;
-    acquireLoggingTestingLock();
-
-    configureLoggingProvider(new shared CustomProvider());
-    auto log = getLogger();
-    log.info("Testing the custom provider.");
-    log.warn("Here is a warning message.");
-
-    releaseLoggingTestingLock();
+    withTestingLock(() {
+        configureLoggingProvider(new CustomProvider());
+        auto log = getLogger();
+        log.info("Testing the custom provider.");
+        log.warn("Here is a warning message.");
+    });
 }

--- a/examples/readme/source/app.d
+++ b/examples/readme/source/app.d
@@ -2,7 +2,7 @@ import slf4d;
 import slf4d.default_provider;
 
 void main() {
-	configureLoggingProvider(new shared DefaultProvider(true, Levels.TRACE));
+	configureLoggingProvider(new DefaultProvider(true, Levels.TRACE));
 
 	example1Main();
 	example2Exceptions();

--- a/examples/testing/source/app.d
+++ b/examples/testing/source/app.d
@@ -17,13 +17,14 @@ void doStuff(int n) {
 
 unittest {
 	import slf4d.test;
-	// Since we're testing how our code interacts with the global state,
-	// we should make sure no other tests can modify it at the same time.
-	synchronized(loggingTestingMutex) {
-		// Check the docs for `getTestingProvider()`. It resets the logging
-		// state and gives you a new `TestingLoggingProvider` instance.
-		auto provider = getTestingProvider();
-
+	/*
+	Since we're testing how our function affects the global logging state, we
+	need to test it in isolation from all other logging. Therefore, we can call
+	useTestingProvider() and provide a delegate function that takes an instance
+	of a TestingLoggingProvider. This code will be executed in a clean logging
+	state, to make sure results are consistent.
+	*/
+	useTestingProvider((TestingLoggingProvider provider) {
 		doStuff(5);
 		provider.assertMessageCount(Levels.INFO, 1);
 		provider.assertMessageCount(Levels.TRACE, 5);
@@ -32,5 +33,5 @@ unittest {
 		doStuff(3);
 		provider.assertHasMessage(Levels.WARN);
 		provider.assertHasMessage("N is too low: 3");
-	}
+	});
 }

--- a/examples/testing/source/app.d
+++ b/examples/testing/source/app.d
@@ -20,11 +20,11 @@ unittest {
 	/*
 	Since we're testing how our function affects the global logging state, we
 	need to test it in isolation from all other logging. Therefore, we can call
-	useTestingProvider() and provide a delegate function that takes an instance
+	withTestingProvider() and provide a delegate function that takes an instance
 	of a TestingLoggingProvider. This code will be executed in a clean logging
 	state, to make sure results are consistent.
 	*/
-	useTestingProvider((TestingLoggingProvider provider) {
+	withTestingProvider((TestingLoggingProvider provider) {
 		doStuff(5);
 		provider.assertMessageCount(Levels.INFO, 1);
 		provider.assertMessageCount(Levels.TRACE, 5);

--- a/source/slf4d/default_provider/handler.d
+++ b/source/slf4d/default_provider/handler.d
@@ -22,7 +22,7 @@ class DefaultLogHandler : LogHandler {
      * Params:
      *   colored = Whether to apply ANSI color codes to output. False by default.
      */
-    public shared this(bool colored = false) {
+    public this(bool colored = false) {
         this.colored = colored;
     }
 
@@ -32,7 +32,7 @@ class DefaultLogHandler : LogHandler {
      * Params:
      *   msg = The message that was produced.
      */
-    public shared void handle(immutable LogMessage msg) {
+    public void handle(immutable LogMessage msg) {
         import std.stdio;
         string logStr = formatLogMessage(msg, this.colored);
         if (msg.level.value >= Levels.ERROR.value) {
@@ -47,7 +47,7 @@ class DefaultLogHandler : LogHandler {
 
 unittest {
     import slf4d.default_provider.provider;
-    auto factory = new shared DefaultProvider(false, Levels.INFO, null).getLoggerFactory();
+    auto factory = new DefaultProvider(false, Levels.INFO, null).getLoggerFactory();
     factory.setRootLevel(Levels.TRACE);
     Logger log = factory.getLogger();
     log.error("Testing default provider error message.");

--- a/source/slf4d/default_provider/provider.d
+++ b/source/slf4d/default_provider/provider.d
@@ -15,7 +15,7 @@ import std.typecons;
  * The default provider class.
  */
 class DefaultProvider : LoggingProvider {
-    private shared DefaultLoggerFactory loggerFactory;
+    private DefaultLoggerFactory loggerFactory;
 
     /** 
      * Constructs the default provider.
@@ -26,29 +26,28 @@ class DefaultProvider : LoggingProvider {
      *   logFileDir = A directory in which to write log files. If `null`, no
      *     files are written.
      */
-    public shared this(
+    public this(
         bool colored = false,
         Level rootLoggingLevel = Levels.INFO,
         string logFileDir = null
     ) {
-        shared LogHandler[] handlers = [new shared DefaultLogHandler(colored)];
+        LogHandler[] handlers = [new DefaultLogHandler(colored)];
         if (logFileDir !is null && logFileDir.length > 0) {
             import slf4d.writer;
-            handlers ~= new shared SerializingLogHandler(
+            handlers ~= new SerializingLogHandler(
                 new DefaultStringLogSerializer(false),
                 new RotatingFileLogWriter(logFileDir)
             );
         }
-        auto baseHandler = new shared MultiLogHandler(handlers);
-        this.loggerFactory = new shared DefaultLoggerFactory(baseHandler, rootLoggingLevel);
+        auto baseHandler = new MultiLogHandler(handlers);
+        this.loggerFactory = new DefaultLoggerFactory(baseHandler, rootLoggingLevel);
     }
     
     /** 
-     * Getter method to get this provider's internal factory. It will lazily
-     * initialize the factory if it hasn't already been initialized.
+     * Getter method to get this provider's internal factory.
      * Returns: The logger factory.
      */
-    public shared shared(DefaultLoggerFactory) getLoggerFactory() {
+    public DefaultLoggerFactory getLoggerFactory() {
         return this.loggerFactory;
     }
 }

--- a/source/slf4d/factory.d
+++ b/source/slf4d/factory.d
@@ -19,5 +19,5 @@ interface LoggerFactory {
      *   name = The name associated with the logger. This will default to the
      *          current module name, which is sufficient for most use cases.
      */
-    shared Logger getLogger(string name = __MODULE__);
+    Logger getLogger(string name = __MODULE__);
 }

--- a/source/slf4d/log_functions.d
+++ b/source/slf4d/log_functions.d
@@ -425,7 +425,7 @@ public void errorF(string fmt, T...)(
 unittest {
     import slf4d.test;
     synchronized (loggingTestingMutex) {
-        shared TestingLoggingProvider provider = getTestingProvider();
+        TestingLoggingProvider provider = getTestingProvider();
         
         // Test formatted functions without any format specifiers.
         logF!"Testing"(Levels.INFO);

--- a/source/slf4d/logger.d
+++ b/source/slf4d/logger.d
@@ -13,9 +13,7 @@ import std.typecons : Nullable, nullable;
  * The logger is the core component of SLF4D. Use it to generate log messages
  * in your code. An ad-hoc Logger can be created and used anywhere, but usually
  * you'll want to use the `getLogger()` function to obtain a pre-configured
- * Logger that has been set up with an application-specific LogHandler. The
- * configured LogHandler is marked as `shared`, because only one root handler
- * instance exists per application.
+ * Logger that has been set up with an application-specific LogHandler.
  * 
  * Note that the D language offers some special keywords like `__MODULE__` and
  * `__PRETTY_FUNCTION__` which at compile time resolve to the respective source
@@ -26,7 +24,7 @@ import std.typecons : Nullable, nullable;
  * to these keywords, and you shouldn't need to ever provide a value for these.
  */
 struct Logger {
-    private shared LogHandler handler;
+    private LogHandler handler;
     public const Level level;
     public const string name;
 
@@ -40,7 +38,7 @@ struct Logger {
      *   name = The name of the logger. It defaults to the name of the module
      *          where the logger was initialized.
      */
-    public this(shared LogHandler handler, Level level = Levels.TRACE, string name = __MODULE__) {
+    public this(LogHandler handler, Level level = Levels.TRACE, string name = __MODULE__) {
         this.handler = handler;
         this.level = level;
         this.name = name;
@@ -68,7 +66,7 @@ struct Logger {
 
     // Test the basic `log` method to ensure log messages are filtered according to the Logger's level.
     unittest {
-        auto handler = new shared CachingLogHandler();
+        auto handler = new CachingLogHandler();
         Logger log = Logger(handler, Levels.INFO);
 
         // Test logging something that's of a sufficient level.
@@ -373,7 +371,7 @@ struct Logger {
     // General test for all functions.
     unittest {
         import slf4d.testing_provider;
-        auto p = new shared TestingLoggingProvider();
+        auto p = new TestingLoggingProvider();
         Logger log = p.getLoggerFactory().getLogger();
 
         log.log(Levels.INFO, "Hello world");

--- a/source/slf4d/noop_provider.d
+++ b/source/slf4d/noop_provider.d
@@ -18,21 +18,21 @@ const Level NO_OP_LEVEL = Level(1_000_000, "NO-OP");
  * produces Loggers whose handler discards any log messages sent to them.
  */
 class NoOpProvider : LoggingProvider {
-    private shared NoOpLoggerFactory factory = new shared NoOpLoggerFactory();
+    private NoOpLoggerFactory factory = new NoOpLoggerFactory();
 
-    shared shared(LoggerFactory) getLoggerFactory() {
+    LoggerFactory getLoggerFactory() {
         return factory;
     }
 }
 
 package class NoOpLoggerFactory : LoggerFactory {
-    shared Logger getLogger(string name = __MODULE__) {
+    Logger getLogger(string name = __MODULE__) {
         return Logger(new DiscardingLogHandler(), NO_OP_LEVEL, name);
     }
 }
 
 unittest {
-    auto factory = new shared NoOpProvider().getLoggerFactory();
+    auto factory = new NoOpProvider().getLoggerFactory();
     auto log = factory.getLogger();
     log.info("This is discarded.");
     log.error("This is also discarded.");

--- a/source/slf4d/provider.d
+++ b/source/slf4d/provider.d
@@ -7,9 +7,8 @@ import slf4d.factory;
 
 /** 
  * This interface should be implemented by any logging provider, such that they
- * supply a shared LoggerFactory that will be used by an application. Note that
- * the provider itself must also be shared.
+ * supply a LoggerFactory that will be used by an application.
  */
 interface LoggingProvider {
-    shared shared(LoggerFactory) getLoggerFactory();
+    LoggerFactory getLoggerFactory();
 }

--- a/source/slf4d/test.d
+++ b/source/slf4d/test.d
@@ -26,10 +26,10 @@ public import slf4d.testing_provider;
  * you acquire a testing lock, that you release it afterwards with
  * `releaseLoggingTestingLock()`.
  */
-public shared Mutex loggingTestingMutex;
+public __gshared Mutex loggingTestingMutex;
 
 static this() {
-    loggingTestingMutex = new shared Mutex();
+    loggingTestingMutex = new Mutex();
 }
 
 /** 
@@ -54,9 +54,34 @@ public void releaseLoggingTestingLock() {
  * a lock for the testing system (or synchronized on the mutex).
  * Returns: The logging provider.
  */
-public shared(TestingLoggingProvider) getTestingProvider() {
+public TestingLoggingProvider getTestingProvider() {
     resetLoggingState();
-    shared TestingLoggingProvider testingProvider = new shared TestingLoggingProvider();
+    TestingLoggingProvider testingProvider = new TestingLoggingProvider();
     configureLoggingProvider(testingProvider);
     return testingProvider;
+}
+
+/**
+ * Convenience function to acquire a lock on the SLF4D logging state and run
+ * some code, then reset the logging state and release the lock.
+ * Params:
+ *   dg = The code to run.
+ */
+public void withTestingLock(void delegate() dg) {
+    acquireLoggingTestingLock();
+    dg();
+    resetLoggingState();
+    releaseLoggingTestingLock();
+}
+
+/**
+ * Convenience function to acquire a lock on the testing state, run some code
+ * (in the provided delegate function), then release the lock.
+ * Params:
+ *   dg = The code to run with the testing logging provider.
+ */
+public void withTestingProvider(void delegate(TestingLoggingProvider) dg) {
+    acquireLoggingTestingLock();
+    dg(getTestingProvider());
+    releaseLoggingTestingLock();
 }

--- a/source/slf4d/testing_provider.d
+++ b/source/slf4d/testing_provider.d
@@ -20,13 +20,13 @@ class TestingLoggingProvider : LoggingProvider {
     /** 
      * The logger factory that this provider uses.
      */
-    public shared TestingLoggerFactory factory;
+    public TestingLoggerFactory factory;
 
-    public shared this() {
-        this.factory = new shared TestingLoggerFactory();
+    public this() {
+        this.factory = new TestingLoggerFactory();
     }
 
-    public shared shared(TestingLoggerFactory) getLoggerFactory() {
+    public TestingLoggerFactory getLoggerFactory() {
         return this.factory;
     }
 
@@ -35,14 +35,14 @@ class TestingLoggingProvider : LoggingProvider {
      * to this provider since the last time it was reset.
      * Returns: The messages that have been logged to this provider.
      */
-    public shared LogMessage[] messages() {
+    public LogMessage[] messages() {
         return this.factory.handler.getMessages();
     }
 
     /** 
      * Convenience method to clear this provider's cached list of messages.
      */
-    public shared void reset() {
+    public void reset() {
         this.factory.handler.reset();
     }
 
@@ -50,7 +50,7 @@ class TestingLoggingProvider : LoggingProvider {
      * Gets the number of messages that have been logged.
      * Returns: The number of messages that have been logged.
      */
-    public shared size_t messageCount() {
+    public size_t messageCount() {
         return this.factory.handler.messageCount;
     }
 
@@ -60,7 +60,7 @@ class TestingLoggingProvider : LoggingProvider {
      *   levelFilter = The level to filter by.
      * Returns: The number of messages that have been logged at the given level.
      */
-    public shared size_t messageCount(Level levelFilter) {
+    public size_t messageCount(Level levelFilter) {
         import std.algorithm : count;
         return cast(size_t) this.messages().count!(m => m.level == levelFilter);
     }
@@ -70,7 +70,7 @@ class TestingLoggingProvider : LoggingProvider {
      * Params:
      *   expected = The expected message count.
      */
-    public shared void assertMessageCount(size_t expected) {
+    public void assertMessageCount(size_t expected) {
         import std.format : format;
         size_t actual = this.messageCount();
         assert(actual == expected, format!"Actual message count %d does not match expected %d."(actual, expected));
@@ -83,7 +83,7 @@ class TestingLoggingProvider : LoggingProvider {
      *   level = The level to filter by.
      *   expected = The expected message count.
      */
-    public shared void assertMessageCount(Level level, size_t expected) {
+    public void assertMessageCount(Level level, size_t expected) {
         import std.format : format;
         size_t actual = this.messageCount(level);
         assert(
@@ -95,7 +95,7 @@ class TestingLoggingProvider : LoggingProvider {
     /** 
      * Asserts that this provider has no cached messages.
      */
-    public shared void assertNoMessages() {
+    public void assertNoMessages() {
         this.assertMessageCount(0);
     }
 
@@ -105,7 +105,7 @@ class TestingLoggingProvider : LoggingProvider {
      * Params:
      *   level = The level to filter by.
      */
-    public shared void assertNoMessages(Level level) {
+    public void assertNoMessages(Level level) {
         this.assertMessageCount(level, 0);
     }
 
@@ -117,7 +117,7 @@ class TestingLoggingProvider : LoggingProvider {
      *        the message matches, or false otherwise.
      *   message = The message to show if no matching log messages are found.
      */
-    public shared void assertHasMessage(
+    public void assertHasMessage(
         bool delegate(LogMessage) dg,
         string message = "No matching log message for delegate function."
     ) {
@@ -132,7 +132,7 @@ class TestingLoggingProvider : LoggingProvider {
      *   expected = The expected string message.
      *   caseSensitive = Whether to do a case-sensitive search. True by default.
      */
-    public shared void assertHasMessage(string expected, bool caseSensitive = true) {
+    public void assertHasMessage(string expected, bool caseSensitive = true) {
         import std.format : format;
         import std.string : toLower;
         this.assertHasMessage(
@@ -151,7 +151,7 @@ class TestingLoggingProvider : LoggingProvider {
      * Params:
      *   level = The logging level to look for.
      */
-    public shared void assertHasMessage(Level level) {
+    public void assertHasMessage(Level level) {
         import std.format : format;
         this.assertHasMessage(
             m => m.level == level,
@@ -165,14 +165,14 @@ class TestingLoggingProvider : LoggingProvider {
  * manner.
  */
 class TestingLoggerFactory : LoggerFactory {
-    public shared CachingLogHandler handler;
+    public CachingLogHandler handler;
     public Level logLevel = Levels.TRACE;
 
-    public shared this() {
-        this.handler = new shared CachingLogHandler();
+    public this() {
+        this.handler = new CachingLogHandler();
     }
 
-    shared Logger getLogger(string name = __MODULE__) {
+    Logger getLogger(string name = __MODULE__) {
         return Logger(this.handler, this.logLevel, name);
     }
 }
@@ -180,7 +180,7 @@ class TestingLoggerFactory : LoggerFactory {
 unittest {
     import slf4d;
 
-    auto p = new shared TestingLoggingProvider();
+    auto p = new TestingLoggingProvider();
     assert(p.messages.length == 0);
     p.assertMessageCount(0);
     p.assertNoMessages();

--- a/source/slf4d/writer.d
+++ b/source/slf4d/writer.d
@@ -210,21 +210,21 @@ class StdoutLogWriter : LogWriter {
  * serializing handler at the end of the day.
  */
 class SerializingLogHandler : LogHandler {
-    private shared LogSerializer serializer;
-    private shared LogWriter writer;
+    private LogSerializer serializer;
+    private LogWriter writer;
 
-    public shared this(LogSerializer serializer, LogWriter writer) {
-        this.serializer = cast(shared(LogSerializer)) serializer;
-        this.writer = cast(shared(LogWriter)) writer;
+    public this(LogSerializer serializer, LogWriter writer) {
+        this.serializer = serializer;
+        this.writer = writer;
     }
 
-    shared void handle(immutable LogMessage msg) {
+    void handle(immutable LogMessage msg) {
         import std.stdio;
         try {
             // We need to cast away this serializer's `shared` attribute to call serialize.
-            string rawMessage = (cast(LogSerializer) this.serializer).serialize(msg);
+            string rawMessage = this.serializer.serialize(msg);
             try {
-                (cast(LogWriter) this.writer).write(rawMessage);
+                this.writer.write(rawMessage);
             } catch (Exception e) {
                 stderr.writefln!"Failed to write log message: %s"(e.msg);
             }
@@ -241,7 +241,7 @@ unittest {
     }
     import slf4d;
     import slf4d.default_provider.factory;
-    auto handler = new shared SerializingLogHandler(
+    auto handler = new SerializingLogHandler(
         new DefaultStringLogSerializer(),
         new RotatingFileLogWriter("test-logs")
     );


### PR DESCRIPTION
It's become clear that it's just too painful to work with the `shared` keyword when it is really just a transitive attribute without any real protections, so I'm removing it.